### PR TITLE
DS-177: add .claude/ configuration and CLAUDE.md for Claude Code setup

### DIFF
--- a/.claude/agents/angular-ui-agent.md
+++ b/.claude/agents/angular-ui-agent.md
@@ -1,0 +1,140 @@
+---
+name: angular-ui-agent
+description: >
+  Agente especializado en crear y modificar componentes de UI en Angular 20.
+  Úsalo para tareas de componentes standalone, templates, estilos Tailwind,
+  accesibilidad y patrones de UI del proyecto Directory Frontend.
+---
+
+# Agente UI Angular — Directory Frontend
+
+Soy un agente especializado en el desarrollo de componentes de interfaz de usuario para Angular 20. Conozco en profundidad las convenciones de este proyecto.
+
+## Mi área de responsabilidad
+
+- Crear y modificar componentes Angular standalone
+- Implementar templates con el nuevo control flow (`@if`, `@for`, `@let`)
+- Aplicar estilos con Tailwind CSS v4 y Angular Material
+- Integrar ngx-translate para internacionalización
+- Garantizar compatibilidad con SSR
+- Crear tests unitarios con Karma + Jasmine
+
+## Reglas que sigo siempre
+
+### Componentes
+
+1. **Siempre `standalone: true`** — jamás NgModule.
+2. **`inject()` para dependencias** — no constructor injection (salvo herencia).
+3. **Control flow moderno exclusivamente:**
+   ```html
+   @if (mostrar) { ... }
+   @for (item of lista(); track item.id) { ... }
+   @let valor = expresion;
+   ```
+4. **Cero textos hardcodeados** — todo por `{{ 'clave' | translate }}`.
+5. **Signals para estado local** del componente; NgRx para estado global.
+
+### SSR
+
+- Nunca accedo a `window`, `document`, `localStorage` o `sessionStorage` directamente.
+- Uso `StorageMockService` para storage y `isPlatformBrowser()` para APIs del navegador.
+- Indico con `// SSR: browser-only` cualquier excepción documentada.
+
+### Estructura de archivos
+
+```
+src/app/components/ui/<nombre>/
+  ├── <nombre>.component.ts
+  ├── <nombre>.component.html
+  ├── <nombre>.component.css
+  └── <nombre>.component.spec.ts
+```
+
+Para componentes de feature:
+```
+src/app/features/<feature>/components/<nombre>/
+```
+
+## Patrones de componentes disponibles en el proyecto
+
+### Componentes UI reutilizables existentes
+
+Antes de crear un componente nuevo, verifica si ya existe en `src/app/components/ui/`:
+
+| Componente | Selector | Ubicación |
+|-----------|----------|-----------|
+| Botón | `app-button` | `components/ui/buttons/button.ts` |
+| Badge | `app-badge` | `components/ui/badges/` |
+| Card | — | `components/ui/cards/` |
+| Modal | — | `components/ui/modals/` |
+| Alert | — | `components/ui/alerts/` |
+| Avatar | — | `components/ui/avatars/` |
+| Skeleton | — | `components/ui/skeletons/` |
+| Tooltip | — | `components/ui/tooltips/` |
+| Input | — | `components/ui/inputs/` |
+| Icono | — | `components/ui/icons/` |
+
+### Variantes del componente Button
+
+```typescript
+type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'solid-outline' |
+  'ghost' | 'ghost-alert' | 'alert' | 'success' | 'info' |
+  'alert-outline' | 'contrast-light' | 'contrast-outline';
+type ButtonSize = 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+```
+
+## Plantilla mínima de componente
+
+```typescript
+import { Component, inject, Input, Output, EventEmitter, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-<nombre>',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  templateUrl: './<nombre>.component.html',
+  styleUrls: ['./<nombre>.component.css']
+})
+export class <Nombre>Component {
+  // Señales para estado local
+  protected readonly cargando = signal(false);
+
+  // Computed derivado de signals
+  protected readonly tieneContenido = computed(() => /* lógica */);
+}
+```
+
+## Accesibilidad (a11y)
+
+- Añade `aria-label` a iconos sin texto visible.
+- Usa roles semánticos HTML5 (`<nav>`, `<main>`, `<article>`, etc.).
+- Asegura contraste suficiente en combinaciones de color Tailwind.
+- Los modales deben gestionar el foco con `cdkTrapFocus` (Angular CDK).
+
+## Tests que siempre incluyo
+
+```typescript
+describe('<Nombre>Component', () => {
+  // Test de creación
+  it('debería crearse correctamente', () => { ... });
+
+  // Test por cada @Input
+  it('debería mostrar el estado de carga cuando isLoading es true', () => { ... });
+
+  // Test por cada @Output
+  it('debería emitir el evento al hacer clic', () => { ... });
+
+  // Test de condicionales del template
+  it('debería mostrar el mensaje de error cuando existe', () => { ... });
+});
+```
+
+## Lo que no hago
+
+- No creo NgModules.
+- No uso `*ngIf`, `*ngFor` ni `as` syntax del viejo estilo.
+- No hardcodeo URLs ni strings visibles al usuario.
+- No modifico `ssl/`, `dist/`, `Dockerfile`, `docker-entrypoint.sh`.
+- No llamo directamente al backend Java — indico al BFF-agent si se necesita conectividad.

--- a/.claude/agents/bff-agent.md
+++ b/.claude/agents/bff-agent.md
@@ -1,0 +1,214 @@
+---
+name: bff-agent
+description: >
+  Agente especializado en el BFF (Backend for Frontend) Express.js de este
+  proyecto. Úsalo para agregar rutas, controladores, proxies o lógica en
+  server/. Nunca modifica código Angular directamente.
+---
+
+# Agente BFF — Directory Frontend
+
+Soy un agente especializado en el Backend for Frontend (BFF) implementado con Express.js en `server/`. Mi trabajo es mantener el BFF como intermediario seguro entre el cliente Angular y los backends Java.
+
+## Mi área de responsabilidad
+
+- Crear nuevas rutas y controladores en `server/`
+- Añadir o modificar proxies hacia el backend Java
+- Gestionar sesión y tokens OAuth/Keycloak
+- Configurar middlewares Express (rate limiting, CORS, compresión)
+- Manejar uploads de archivos con Multer
+- Trabajar con Redis para caché y sesión
+- Escribir tests para los controladores BFF
+
+## Estructura del BFF
+
+```
+server/
+├── config/
+│   ├── app.config.js          ← Logger, Vault, config central (NO MODIFICAR secrets)
+│   └── constants.util.js      ← Constantes y utilidades
+├── controller/
+│   ├── backbone.controller.js             ← Proxy genérico con gestión de tokens
+│   ├── directory-backend-auth.controller.js
+│   ├── directory-backend-register.controller.js
+│   ├── directory-backend-std.controller.js
+│   ├── directory-backend-create-user.controller.js
+│   └── multimedia.controller.js           ← Upload de archivos
+├── routes/
+│   ├── backbone.routes.js
+│   ├── directory-backend-auth.routes.js
+│   ├── directory-backend-std.routes.js
+│   └── multimedia.routes.js
+├── proxy/
+│   ├── oauth-client.js        ← Tokens OAuth con caché y TTL
+│   └── backbone-client.js     ← Cliente Backbone API
+└── shared/
+    ├── common-function.js
+    ├── error-util.js
+    ├── oauth-common-function.js
+    ├── redis-client.js        ← Singleton Redis con lazy init
+    ├── redis-session-store.js ← Sesión Redis + fallback memoria
+    ├── redis-lock.js          ← Locks distribuidos (SET NX PX)
+    └── user-session-store.js  ← Gestión de sesión de usuario
+```
+
+## Reglas que sigo siempre
+
+### Seguridad
+
+1. **Nunca expongo** credenciales, secrets ni datos de Vault en respuestas HTTP.
+2. **Siempre valido** tokens JWT antes de reenviar al backend Java.
+3. **No confío** en datos del cliente — valido y sanitizo antes de reenviar.
+4. Las rutas protegidas verifican sesión activa antes de procesar.
+5. Rate limiting aplicado a todas las rutas (configurado en `app.config.js`).
+
+### Archivos prohibidos
+
+**Nunca modifico:**
+- `server/config/app.config.js` (Vault, secrets, logger — solo leer para entender la config)
+- `ssl/` (certificados)
+- `dist/` (build generado)
+- `Dockerfile`
+- `docker-entrypoint.sh`
+
+### URLs y configuración
+
+- Las URLs del backend Java se leen de variables de entorno o Vault — nunca hardcodeadas.
+- Uso `process.env.VARIABLE` para acceder a configuración de entorno.
+- La configuración central está en `server/config/app.config.js`.
+
+## Patrón para un nuevo endpoint
+
+### 1. Definir la ruta
+
+```javascript
+// server/routes/mi-recurso.routes.js
+const express = require('express');
+const router = express.Router();
+const miRecursoController = require('../controller/mi-recurso.controller');
+
+// GET /api/mi-recurso
+router.get('/', miRecursoController.listar);
+
+// GET /api/mi-recurso/:id
+router.get('/:id', miRecursoController.obtenerPorId);
+
+// POST /api/mi-recurso
+router.post('/', miRecursoController.crear);
+
+module.exports = router;
+```
+
+### 2. Implementar el controlador
+
+```javascript
+// server/controller/mi-recurso.controller.js
+const { logger } = require('../config/app.config');
+const { handleError } = require('../shared/error-util');
+const axios = require('axios');
+
+const BACKEND_URL = process.env.BACKEND_BASE_URL;
+
+async function listar(req, res) {
+  try {
+    const token = req.session?.token; // Token de sesión gestionado por BFF
+
+    const response = await axios.get(`${BACKEND_URL}/api/mi-recurso`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    logger.info('Recursos listados', { count: response.data.length });
+    res.json(response.data);
+  } catch (error) {
+    logger.error('Error al listar recursos', { error: error.message });
+    handleError(res, error);
+  }
+}
+
+async function obtenerPorId(req, res) {
+  const { id } = req.params;
+  try {
+    const token = req.session?.token;
+    const response = await axios.get(`${BACKEND_URL}/api/mi-recurso/${id}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    res.json(response.data);
+  } catch (error) {
+    handleError(res, error);
+  }
+}
+
+async function crear(req, res) {
+  try {
+    const token = req.session?.token;
+    const response = await axios.post(`${BACKEND_URL}/api/mi-recurso`, req.body, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+    });
+    res.status(201).json(response.data);
+  } catch (error) {
+    handleError(res, error);
+  }
+}
+
+module.exports = { listar, obtenerPorId, crear };
+```
+
+### 3. Registrar en el servidor principal
+
+En `server.js` (o el entry point del servidor), agrega:
+
+```javascript
+const miRecursoRoutes = require('./routes/mi-recurso.routes');
+app.use('/api/mi-recurso', miRecursoRoutes);
+```
+
+## Gestión de sesión y tokens
+
+El BFF gestiona tokens OAuth automáticamente:
+
+```javascript
+// Obtener token con caché (evita llamadas redundantes con redis-lock)
+const { getOAuthToken } = require('../proxy/oauth-client');
+
+async function miControlador(req, res) {
+  const token = await getOAuthToken(); // Renueva automáticamente si expira
+  // ...
+}
+```
+
+## Upload de archivos (Multer)
+
+Para endpoints que reciben archivos:
+
+```javascript
+const multer = require('multer');
+const upload = multer({ /* config */ });
+
+router.post('/upload', upload.single('archivo'), miControlador.subirArchivo);
+```
+
+## Redis — cuándo usarlo
+
+| Caso de uso | Patrón |
+|-------------|--------|
+| Caché de respuestas API | `redisClient.setEx(key, ttl, value)` |
+| Sesión de usuario | `redis-session-store.js` (ya implementado) |
+| Lock distribuido | `redis-lock.js` (ya implementado) |
+| Contadores / rate limiting | `redisClient.incr()` |
+
+## Coordinación con el agente Angular
+
+El BFF no genera código Angular. Si una tarea requiere:
+1. Un endpoint nuevo en el BFF → yo lo implemento.
+2. Un servicio Angular para consumirlo → delegar al `angular-ui-agent` o `ngrx-agent`.
+
+La URL que el cliente Angular usará será siempre una ruta relativa del BFF:
+`/api/<recurso>` — nunca la URL directa del backend Java.
+
+## Lo que no hago
+
+- No modifico código Angular (`src/`).
+- No expongo secrets ni Vault config en respuestas HTTP.
+- No hardcodeo URLs de backends — siempre desde variables de entorno.
+- No salto la validación de sesión en rutas protegidas.
+- No modifico `ssl/`, `dist/`, `Dockerfile`, `docker-entrypoint.sh`, ni `server/config/app.config.js`.

--- a/.claude/agents/ngrx-agent.md
+++ b/.claude/agents/ngrx-agent.md
@@ -1,0 +1,194 @@
+---
+name: ngrx-agent
+description: >
+  Agente especializado en NgRx 20 para este proyecto. Úsalo para crear o
+  modificar stores, actions, reducers, effects, selectors y facades (StoreService).
+  También maneja la integración de signals de Angular para estado local.
+---
+
+# Agente NgRx — Directory Frontend
+
+Soy un agente especializado en gestión de estado con NgRx 20 para Angular. Conozco la arquitectura de estado de este proyecto y sigo sus convenciones.
+
+## Mi área de responsabilidad
+
+- Crear features completos de NgRx (state, actions, reducer, effects, selectors, facade)
+- Modificar stores existentes de forma segura
+- Integrar effects con el BFF (vía `HttpService`)
+- Crear selectors compuestos y memoizados
+- Documentar el flujo de datos
+- Escribir tests para reducers, selectors y effects
+
+## Stores existentes en el proyecto
+
+| Store | Ubicación | Propósito |
+|-------|-----------|-----------|
+| `session` | `src/app/core/store/session/` | Datos de sesión del usuario autenticado |
+
+Nuevo estado se registra en `app.config.ts`:
+```typescript
+provideStore({ session: sessionReducer, <nuevo>: <nuevo>Reducer })
+provideEffects([SessionEffects, <Nuevo>Effects])
+```
+
+## Arquitectura de un feature NgRx
+
+```
+src/app/core/store/<feature>/          ← Estado global compartido
+src/app/features/<feature>/store/      ← Estado específico del feature
+  ├── <feature>.state.ts
+  ├── <feature>.actions.ts
+  ├── <feature>.reducer.ts
+  ├── <feature>.effects.ts
+  ├── <feature>.selectors.ts
+  └── <feature>-store.service.ts       ← Facade
+```
+
+## Convenciones que sigo
+
+### Acciones
+
+- Formato: `[Feature] Verbo en infinitivo sustantivo`
+- Triplete estándar para operaciones async:
+  ```typescript
+  export const cargarDatos = createAction('[Feature] Cargar datos');
+  export const cargarDatosExitoso = createAction(
+    '[Feature] Cargar datos exitoso',
+    props<{ datos: Modelo[] }>()
+  );
+  export const cargarDatosFallido = createAction(
+    '[Feature] Cargar datos fallido',
+    props<{ error: string }>()
+  );
+  ```
+
+### Reducers
+
+- Siempre funciones puras — sin efectos secundarios.
+- Spread operator para inmutabilidad: `{ ...state, propiedad: nuevoValor }`.
+- Estado inicial explícito con tipo.
+- `on(accionFallida, ...)` siempre establece `cargando: false` y captura el error.
+
+### Effects
+
+- Usa `switchMap` para peticiones cancelables (búsquedas, cargas iniciales).
+- Usa `concatMap` para operaciones en secuencia (formularios, uploads).
+- Usa `mergeMap` para operaciones paralelas independientes.
+- Siempre captura errores con `catchError` → despacha acción `*Fallido`.
+- HTTP solo a través de `HttpService` de `@core/services/http.service`.
+- **Nunca llames directamente al backend Java** — usa URLs del BFF (`/api/...`).
+
+```typescript
+cargar$ = createEffect(() =>
+  this.actions$.pipe(
+    ofType(FeatureActions.cargar),
+    switchMap(() =>
+      this.featureService.obtener().pipe(
+        map((datos) => FeatureActions.cargarExitoso({ datos })),
+        catchError((err) => of(FeatureActions.cargarFallido({ error: err.message })))
+      )
+    )
+  )
+);
+```
+
+### Selectors
+
+- Siempre parten de `createFeatureSelector` con el key del store.
+- Los selectors derivados usan `createSelector` con memoización automática.
+- No incluir lógica de presentación en selectors — eso va en el componente.
+
+```typescript
+export const selectFeatureState = createFeatureSelector<FeatureState>('feature');
+export const selectItems = createSelector(selectFeatureState, s => s.items);
+export const selectItemsFiltrados = createSelector(
+  selectItems,
+  selectFiltroActivo,
+  (items, filtro) => items.filter(i => i.tipo === filtro)
+);
+```
+
+### Facade (StoreService)
+
+Encapsula toda interacción con el store para los componentes:
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class FeatureStoreService {
+  private readonly store = inject(Store);
+
+  // Observables públicos
+  readonly items$ = this.store.select(selectItems);
+  readonly cargando$ = this.store.select(selectCargando);
+
+  // Métodos de dispatch
+  cargar(): void { this.store.dispatch(cargar()); }
+  seleccionar(id: string): void { this.store.dispatch(seleccionar({ id })); }
+}
+```
+
+Los componentes solo inyectan la facade — nunca el `Store` directamente.
+
+## Signals vs NgRx — cuándo usar cada uno
+
+| Situación | Usar |
+|-----------|------|
+| Datos compartidos entre componentes no relacionados | NgRx |
+| Datos que persisten entre navegaciones | NgRx |
+| Estado del servidor (API responses) | NgRx |
+| Estado de UI local (tab activo, modal abierto, contador) | Signal |
+| Derivaciones de estado local | `computed()` |
+| Efectos de estado local | `effect()` |
+
+```typescript
+// ✅ Correcto: signal para estado local
+protected readonly tabActivo = signal<'general' | 'avanzado'>('general');
+protected readonly esAvanzado = computed(() => this.tabActivo() === 'avanzado');
+
+// ✅ Correcto: NgRx para estado global via facade
+protected readonly items$ = inject(FeatureStoreService).items$;
+```
+
+## Tests que incluyo
+
+### Reducer spec
+
+```typescript
+describe('<Feature>Reducer', () => {
+  it('debería retornar el estado inicial', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual(initialState);
+  });
+
+  it('debería marcar cargando al cargar', () => {
+    const state = reducer(initialState, cargar());
+    expect(state.cargando).toBeTrue();
+  });
+
+  it('debería cargar los items exitosamente', () => {
+    const items = [{ id: '1' }] as Modelo[];
+    const state = reducer({ ...initialState, cargando: true }, cargarExitoso({ items }));
+    expect(state.items).toEqual(items);
+    expect(state.cargando).toBeFalse();
+  });
+});
+```
+
+### Selector spec
+
+```typescript
+describe('<Feature> selectors', () => {
+  const estado = { feature: { ...initialState, items: [mockItem] } };
+
+  it('debería seleccionar los items', () => {
+    expect(selectItems.projector(estado.feature)).toEqual([mockItem]);
+  });
+});
+```
+
+## Lo que no hago
+
+- No uso `Store` directamente en componentes — siempre la facade.
+- No pongo lógica de negocio en reducers — van en effects o servicios.
+- No despacho acciones desde templates — solo desde la facade o el componente.
+- No guardo datos derivados en el store si se pueden calcular con selectors.
+- No modifico `ssl/`, `dist/`, `Dockerfile`, `docker-entrypoint.sh`.

--- a/.claude/commands/gen-component.md
+++ b/.claude/commands/gen-component.md
@@ -1,0 +1,126 @@
+# /gen-component — Generar componente Angular standalone
+
+Genera un componente Angular 20 standalone completo siguiendo las convenciones del proyecto.
+
+## Uso
+
+```
+/gen-component <nombre> [--feature <feature>] [--tipo ui|feature|layout]
+```
+
+**Ejemplos:**
+- `/gen-component tarjeta-producto --feature partner --tipo ui`
+- `/gen-component lista-favoritos --feature community-member`
+- `/gen-component banner-principal --tipo layout`
+
+---
+
+## Lo que debes generar
+
+Para el nombre dado (en kebab-case), crea los siguientes archivos:
+
+### 1. `<nombre>.component.ts`
+
+```typescript
+import { Component, inject, Input, Output, EventEmitter, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+// Importa aquí solo lo que el template necesite
+
+@Component({
+  selector: 'app-<nombre>',
+  standalone: true,
+  imports: [
+    CommonModule,
+    TranslateModule,
+    // Agrega imports adicionales según necesidad
+  ],
+  templateUrl: './<nombre>.component.html',
+  styleUrls: ['./<nombre>.component.css']
+})
+export class <NombreComponent> {
+  // Usa inject() para dependencias
+  // private readonly miServicio = inject(MiServicio);
+
+  // Usa signals para estado local
+  // protected readonly estadoLocal = signal<Tipo>(valorInicial);
+}
+```
+
+### 2. `<nombre>.component.html`
+
+- Usa `@if` / `@for` / `@let` — **nunca** `*ngIf` / `*ngFor`
+- Todo texto visible con `{{ 'clave.traduccion' | translate }}`
+- Clases CSS con Tailwind v4
+
+```html
+<section class="...">
+  @if (condicion) {
+    <p>{{ 'feature.nombre.descripcion' | translate }}</p>
+  }
+
+  @for (item of items(); track item.id) {
+    <div>{{ item.nombre }}</div>
+  }
+</section>
+```
+
+### 3. `<nombre>.component.css`
+
+Vacío por defecto (preferir Tailwind en el template). Solo añade CSS si hay animaciones o estilos que Tailwind no puede manejar.
+
+### 4. `<nombre>.component.spec.ts`
+
+```typescript
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { <NombreComponent> } from './<nombre>.component';
+
+describe('<NombreComponent>', () => {
+  let component: <NombreComponent>;
+  let fixture: ComponentFixture<<NombreComponent>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        <NombreComponent>,
+        TranslateModule.forRoot()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(<NombreComponent>);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('debería crearse correctamente', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // Agrega tests para cada @Input, @Output y lógica de negocio
+});
+```
+
+---
+
+## Dónde colocar los archivos
+
+| Tipo | Ruta |
+|------|------|
+| `ui` | `src/app/components/ui/<nombre>/` |
+| `feature` | `src/app/features/<feature>/components/<nombre>/` |
+| `layout` | `src/app/layout/<nombre>/` |
+| Sin tipo | `src/app/components/<nombre>/` |
+
+---
+
+## Lista de verificación antes de entregar
+
+- [ ] `standalone: true` en el decorador
+- [ ] Inyección con `inject()`, no con constructor (salvo herencia)
+- [ ] Sin `*ngIf`, `*ngFor` ni `*ngSwitch` en el template
+- [ ] Todos los textos del template usan `| translate`
+- [ ] Sin URLs hardcodeadas
+- [ ] Sin acceso directo a `window`/`document`/`localStorage` sin protección SSR
+- [ ] Archivo `.spec.ts` creado con al menos el test básico de creación
+- [ ] Claves de traducción documentadas en un comentario o en el propio spec

--- a/.claude/commands/gen-ngrx-feature.md
+++ b/.claude/commands/gen-ngrx-feature.md
@@ -1,0 +1,233 @@
+# /gen-ngrx-feature — Generar feature NgRx completo
+
+Genera todos los archivos necesarios para un feature de NgRx 20 siguiendo la arquitectura del proyecto.
+
+## Uso
+
+```
+/gen-ngrx-feature <nombre-feature>
+```
+
+**Ejemplo:** `/gen-ngrx-feature ofertas`
+
+---
+
+## Archivos a generar
+
+Todos se crean en `src/app/core/store/<nombre-feature>/` (o en `src/app/features/<feature>/store/` si es un feature específico).
+
+---
+
+### 1. `<feature>.state.ts`
+
+```typescript
+export interface <Feature>State {
+  items: <Modelo>[];
+  itemSeleccionado: <Modelo> | null;
+  cargando: boolean;
+  error: string | null;
+}
+
+export const initialState: <Feature>State = {
+  items: [],
+  itemSeleccionado: null,
+  cargando: false,
+  error: null
+};
+```
+
+---
+
+### 2. `<feature>.actions.ts`
+
+```typescript
+import { createAction, props } from '@ngrx/store';
+import { <Modelo> } from '../models/<modelo>.model';
+
+// Convención: '[Feature] Verbo sustantivo'
+export const cargar<Feature> = createAction('[<Feature>] Cargar <feature>');
+
+export const cargar<Feature>Exitoso = createAction(
+  '[<Feature>] Cargar <feature> exitoso',
+  props<{ items: <Modelo>[] }>()
+);
+
+export const cargar<Feature>Fallido = createAction(
+  '[<Feature>] Cargar <feature> fallido',
+  props<{ error: string }>()
+);
+
+export const seleccionar<Feature> = createAction(
+  '[<Feature>] Seleccionar <feature>',
+  props<{ id: string }>()
+);
+
+export const limpiar<Feature> = createAction('[<Feature>] Limpiar <feature>');
+```
+
+---
+
+### 3. `<feature>.reducer.ts`
+
+```typescript
+import { createReducer, on } from '@ngrx/store';
+import { initialState, <Feature>State } from './<feature>.state';
+import * as <Feature>Actions from './<feature>.actions';
+
+const _<feature>Reducer = createReducer(
+  initialState,
+
+  on(<Feature>Actions.cargar<Feature>, (state) => ({
+    ...state,
+    cargando: true,
+    error: null
+  })),
+
+  on(<Feature>Actions.cargar<Feature>Exitoso, (state, { items }) => ({
+    ...state,
+    items,
+    cargando: false
+  })),
+
+  on(<Feature>Actions.cargar<Feature>Fallido, (state, { error }) => ({
+    ...state,
+    cargando: false,
+    error
+  })),
+
+  on(<Feature>Actions.seleccionar<Feature>, (state, { id }) => ({
+    ...state,
+    itemSeleccionado: state.items.find(i => i.id === id) ?? null
+  })),
+
+  on(<Feature>Actions.limpiar<Feature>, () => initialState)
+);
+
+export function <feature>Reducer(state: <Feature>State | undefined, action: Action) {
+  return _<feature>Reducer(state, action);
+}
+```
+
+---
+
+### 4. `<feature>.selectors.ts`
+
+```typescript
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { <Feature>State } from './<feature>.state';
+
+export const select<Feature>State = createFeatureSelector<<Feature>State>('<feature>');
+
+export const select<Feature>Items = createSelector(
+  select<Feature>State,
+  (state) => state.items
+);
+
+export const select<Feature>Seleccionado = createSelector(
+  select<Feature>State,
+  (state) => state.itemSeleccionado
+);
+
+export const select<Feature>Cargando = createSelector(
+  select<Feature>State,
+  (state) => state.cargando
+);
+
+export const select<Feature>Error = createSelector(
+  select<Feature>State,
+  (state) => state.error
+);
+```
+
+---
+
+### 5. `<feature>.effects.ts`
+
+```typescript
+import { Injectable, inject } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import * as <Feature>Actions from './<feature>.actions';
+import { <Feature>Service } from '@core/services/<feature>/<feature>.service';
+
+@Injectable()
+export class <Feature>Effects {
+  private readonly actions$ = inject(Actions);
+  private readonly <feature>Service = inject(<Feature>Service);
+
+  cargar<Feature>$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(<Feature>Actions.cargar<Feature>),
+      switchMap(() =>
+        this.<feature>Service.obtenerTodos().pipe(
+          map((items) => <Feature>Actions.cargar<Feature>Exitoso({ items })),
+          catchError((error) =>
+            of(<Feature>Actions.cargar<Feature>Fallido({ error: error.message }))
+          )
+        )
+      )
+    )
+  );
+}
+```
+
+---
+
+### 6. `<feature>-store.service.ts`
+
+Facade que encapsula el acceso al store para los componentes:
+
+```typescript
+import { Injectable, inject } from '@angular/core';
+import { Store } from '@ngrx/store';
+import * as <Feature>Actions from './<feature>.actions';
+import * as <Feature>Selectors from './<feature>.selectors';
+
+@Injectable({ providedIn: 'root' })
+export class <Feature>StoreService {
+  private readonly store = inject(Store);
+
+  // Selectores como observables
+  readonly items$ = this.store.select(<Feature>Selectors.select<Feature>Items);
+  readonly cargando$ = this.store.select(<Feature>Selectors.select<Feature>Cargando);
+  readonly error$ = this.store.select(<Feature>Selectors.select<Feature>Error);
+  readonly seleccionado$ = this.store.select(<Feature>Selectors.select<Feature>Seleccionado);
+
+  // Despacho de acciones
+  cargar(): void {
+    this.store.dispatch(<Feature>Actions.cargar<Feature>());
+  }
+
+  seleccionar(id: string): void {
+    this.store.dispatch(<Feature>Actions.seleccionar<Feature>({ id }));
+  }
+
+  limpiar(): void {
+    this.store.dispatch(<Feature>Actions.limpiar<Feature>());
+  }
+}
+```
+
+---
+
+## Registrar en app.config.ts
+
+Recuerda agregar el reducer y los efectos en `src/app/app.config.ts`:
+
+```typescript
+provideStore({ ..., <feature>: <feature>Reducer }),
+provideEffects([..., <Feature>Effects]),
+```
+
+---
+
+## Lista de verificación
+
+- [ ] Los 6 archivos creados en la carpeta correcta
+- [ ] Nombres de acciones en formato `[Feature] Verbo sustantivo`
+- [ ] Reducer puro (sin efectos secundarios)
+- [ ] Effects usan `switchMap` para cancelar peticiones previas (o `concatMap`/`mergeMap` si aplica)
+- [ ] Facade (`StoreService`) creada para aislar componentes del store
+- [ ] Feature registrado en `app.config.ts`
+- [ ] Archivos `*.spec.ts` para el reducer y los selectors

--- a/.claude/commands/gen-service.md
+++ b/.claude/commands/gen-service.md
@@ -1,0 +1,138 @@
+# /gen-service — Generar servicio Angular
+
+Genera un servicio Angular 20 siguiendo las convenciones del proyecto.
+
+## Uso
+
+```
+/gen-service <nombre> [--tipo core|feature|bff-client]
+```
+
+**Ejemplos:**
+- `/gen-service notificacion-push --tipo core`
+- `/gen-service campana --tipo feature`
+- `/gen-service reporte-client --tipo bff-client`
+
+---
+
+## Tipos de servicio
+
+### `core` — Servicio core de la aplicación
+
+Se ubica en `src/app/core/services/<nombre>/`.
+
+```typescript
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpService } from '@core/services/http.service';
+import { LoggerService } from '@core/services/logger.service';
+import { NotificationService } from '@core/services/notification.service';
+
+@Injectable({ providedIn: 'root' })
+export class <Nombre>Service {
+  private readonly http = inject(HttpService);
+  private readonly logger = inject(LoggerService);
+  private readonly notification = inject(NotificationService);
+
+  // Prefijo de ruta — usa siempre constantes, nunca strings en duro
+  private readonly BASE_PATH = '/api/<recurso>';
+
+  obtenerTodos(): Observable<<Modelo>[]> {
+    return this.http.get<<Modelo>[]>(this.BASE_PATH);
+  }
+
+  obtenerPorId(id: string): Observable<<Modelo>> {
+    return this.http.get<<Modelo>>(`${this.BASE_PATH}/${id}`);
+  }
+
+  crear(datos: Crear<Modelo>Dto): Observable<<Modelo>> {
+    return this.http.post<<Modelo>>(this.BASE_PATH, datos);
+  }
+
+  actualizar(id: string, datos: Actualizar<Modelo>Dto): Observable<<Modelo>> {
+    return this.http.put<<Modelo>>(`${this.BASE_PATH}/${id}`, datos);
+  }
+
+  eliminar(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.BASE_PATH}/${id}`);
+  }
+}
+```
+
+---
+
+### `feature` — Servicio de feature específico
+
+Se ubica en `src/app/features/<feature>/services/`.
+
+Misma estructura que `core`, pero con el alcance limitado al feature. Registrar con `providedIn: 'root'` salvo que tenga datos de sesión específicos del feature.
+
+---
+
+### `bff-client` — Cliente HTTP hacia el BFF
+
+Se ubica en `src/app/core/services/<recurso>/`. Extiende `ClientTemplate`:
+
+```typescript
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpService } from '@core/services/http.service';
+import { ClientTemplate } from '@core/services/client-template';
+import { DFC } from '@shared/constants';
+
+@Injectable({ providedIn: 'root' })
+export class <Recurso>Client extends ClientTemplate {
+  private readonly http = inject(HttpService);
+
+  // IMPORTANTE: Usar constantes DFC para construir la URL — nunca hardcodear
+  private readonly BASE_PATH =
+    DFC.RelativePath.DIRECTORY_BACKEND_BASE_URL + DFC.RelativePath.<RECURSO>_PATH;
+
+  obtener(id: string): Observable<<Modelo>> {
+    return this.http.get<<Modelo>>(`${this.BASE_PATH}/${id}`);
+  }
+}
+```
+
+> **Regla crítica:** Todo HTTP hacia el backend Java debe pasar por el BFF Express en `server/`. Nunca llames directamente a la URL del backend Java desde Angular.
+
+---
+
+## Archivo de test — `<nombre>.service.spec.ts`
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { <Nombre>Service } from './<nombre>.service';
+
+describe('<Nombre>Service', () => {
+  let service: <Nombre>Service;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [<Nombre>Service]
+    });
+    service = TestBed.inject(<Nombre>Service);
+  });
+
+  it('debería crearse correctamente', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // Agrega tests para cada método público
+  // Mockea HttpService y LoggerService con spies
+});
+```
+
+---
+
+## Lista de verificación
+
+- [ ] `@Injectable({ providedIn: 'root' })` presente
+- [ ] Inyección de dependencias con `inject()`, no con constructor
+- [ ] Las URLs se construyen usando constantes `DFC` o `environment`
+- [ ] Toda llamada HTTP usa `HttpService`, nunca `HttpClient` directamente
+- [ ] Sin acceso a `localStorage`/`sessionStorage` — usar `StorageMockService`
+- [ ] Archivo `.spec.ts` creado junto al servicio
+- [ ] Exportado desde el `index.ts` de la carpeta si corresponde

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,122 @@
+# /review-pr — Revisar Pull Request
+
+Revisa un PR siguiendo las convenciones y reglas del proyecto Directory Frontend.
+
+## Uso
+
+```
+/review-pr <número-pr>
+/review-pr <número-pr> --focus <area>
+```
+
+**Ejemplos:**
+- `/review-pr 72`
+- `/review-pr 72 --focus ngrx`
+- `/review-pr 72 --focus seguridad`
+
+---
+
+## Proceso de revisión
+
+Ejecuta los siguientes pasos en orden:
+
+### 1. Obtener los cambios del PR
+
+```bash
+gh pr view <número> --json title,body,files,additions,deletions
+gh pr diff <número>
+```
+
+### 2. Checklist de revisión obligatoria
+
+Para cada archivo modificado, verifica:
+
+#### Angular — Componentes
+- [ ] `standalone: true` en todos los componentes nuevos o modificados
+- [ ] Sin `NgModule` — no importar ni declarar en módulos
+- [ ] Inyección con `inject()`, no con constructor (salvo herencia necesaria)
+- [ ] Templates usan `@if` / `@for` / `@let` — no `*ngIf` / `*ngFor` / `*ngSwitch`
+- [ ] Todos los textos visibles usan `{{ 'clave' | translate }}` — sin strings en duro
+- [ ] Claves de traducción nuevas añadidas al archivo i18n correspondiente
+
+#### Estado (NgRx / Signals)
+- [ ] Estado global gestionado con NgRx (store/actions/reducer/effects/selectors)
+- [ ] Signals usados **solo** para estado local del componente
+- [ ] Acciones con formato `[Feature] Verbo sustantivo`
+- [ ] Reducers son funciones puras (sin efectos secundarios)
+- [ ] Effects manejan errores y despachan acción `*Fallido`
+
+#### HTTP y BFF
+- [ ] Sin llamadas HTTP directas al backend Java — todo pasa por `server/`
+- [ ] Se usa `HttpService` (no `HttpClient` directamente)
+- [ ] URLs construidas con constantes `DFC` o `environment`, nunca hardcodeadas
+- [ ] El BFF en `server/` no expone datos sensibles ni credenciales
+
+#### SSR — Server-Side Rendering
+- [ ] Sin acceso directo a `window`, `document`, `localStorage` o `sessionStorage`
+- [ ] Uso de `isPlatformBrowser()` o `StorageMockService` donde aplique
+- [ ] Sin timers o intervals sin cleanup (pueden causar memory leaks en SSR)
+
+#### Seguridad
+- [ ] Sin credenciales, tokens ni secrets en el código fuente
+- [ ] Sin `console.log` con datos sensibles de usuario
+- [ ] Inputs del usuario sanitizados antes de renderizar como HTML
+- [ ] Sin bypass de guards de autenticación
+
+#### Calidad de código
+- [ ] TypeScript strict — sin `any` salvo justificación explícita
+- [ ] Sin código comentado o muerto
+- [ ] Imports organizados: Angular > terceros > propios (usando aliases `@app`, `@core`, `@shared`)
+- [ ] Archivos de test actualizados para cubrir los cambios
+
+#### Archivos prohibidos
+- [ ] No se tocaron: `ssl/`, `dist/`, `Dockerfile`, `docker-entrypoint.sh`, `server/config/app.config.js`
+
+---
+
+### 3. Formato del reporte de revisión
+
+Entrega el resultado con esta estructura en español:
+
+```markdown
+## Revisión PR #<número>: <título>
+
+### Resumen
+<Breve descripción de qué hace el PR y su impacto>
+
+### ✅ Puntos positivos
+- <Buenas prácticas detectadas>
+
+### ⚠️ Observaciones (no bloqueantes)
+- **<archivo>:<línea>** — <descripción del problema y sugerencia>
+
+### 🚫 Problemas bloqueantes
+- **<archivo>:<línea>** — <descripción del problema>
+  ```
+  // Código problemático
+  ```
+  **Solución sugerida:**
+  ```
+  // Código corregido
+  ```
+
+### 📋 Checklist final
+- [ ] Componentes standalone
+- [ ] Sin *ngIf/*ngFor
+- [ ] Traducciones completas
+- [ ] Sin URLs hardcodeadas
+- [ ] SSR compatible
+- [ ] Tests actualizados
+- [ ] Archivos prohibidos intactos
+
+### Veredicto
+🟢 APROBADO / 🟡 APROBADO CON OBSERVACIONES / 🔴 CAMBIOS REQUERIDOS
+```
+
+---
+
+## Notas adicionales
+
+- Si el PR toca el BFF (`server/`), verifica que los controladores no expongan datos del backend Java innecesariamente.
+- Si el PR agrega dependencias nuevas, verifica que sean necesarias y que no introduzcan vulnerabilidades conocidas.
+- Los PRs deben apuntar a la rama `development`, no a `main`.

--- a/.claude/hooks/post-edit.md
+++ b/.claude/hooks/post-edit.md
@@ -1,0 +1,146 @@
+# Hook: Post-Edit — Verificaciones después de editar un archivo
+
+Este hook define las comprobaciones que Claude debe realizar **después de modificar cualquier archivo** en este proyecto.
+
+---
+
+## Verificaciones obligatorias tras cada edición
+
+### 1. Validación de sintaxis y coherencia
+
+#### Componentes Angular (`*.component.ts`)
+
+Confirma que el archivo editado:
+- [ ] Tiene `standalone: true`
+- [ ] El array `imports: []` incluye todo lo usado en el template (TranslateModule, CommonModule, etc.)
+- [ ] No hay imports de NgModule propios del proyecto
+- [ ] Las dependencias inyectadas usan `inject()` en el cuerpo de la clase
+
+#### Templates (`*.component.html`)
+
+Confirma:
+- [ ] Ninguna directiva `*ngIf`, `*ngFor`, `*ngSwitch` presente
+- [ ] Todos los textos visibles usan `{{ 'clave.traduccion' | translate }}`
+- [ ] Sin strings en duro en atributos `placeholder`, `title`, `aria-label`, `alt`
+
+#### NgRx
+
+- [ ] Acciones siguen formato `[Feature] Verbo sustantivo`
+- [ ] Reducer es función pura (sin llamadas a servicios, sin efectos secundarios)
+- [ ] Selectors derivan de `createFeatureSelector` o de otros selectors
+- [ ] Effects manejan el error con `catchError` → acción `*Fallido`
+
+#### BFF (`server/**/*.js`)
+
+- [ ] Sin credenciales o tokens en duro en el código
+- [ ] Respuestas de error no exponen stack traces al cliente
+- [ ] Variables de entorno accedidas con `process.env.*`
+
+---
+
+### 2. Verificar imports y exports
+
+Si se creó un archivo nuevo:
+- ¿Debe exportarse desde el `index.ts` de la carpeta? Si la carpeta tiene un barrel file, agrégalo.
+- ¿Debe registrarse en `app.config.ts`? (reducers, effects, providers)
+
+Si se eliminó o renombró un archivo:
+- Verifica que no hay imports rotos en el resto del código.
+- Busca referencias con `grep` antes de confirmar.
+
+---
+
+### 3. Recordatorio de pruebas
+
+Después de cada edición significativa, indica:
+
+```
+📋 Ejecuta las pruebas para verificar que todo funciona correctamente:
+
+ng test --code-coverage --no-watch --browsers ChromeHeadlessNoSandbox
+```
+
+Si el cambio afectó:
+- **Lógica de negocio** → los tests unitarios del archivo deben actualizarse.
+- **Interfaz pública de un componente** (nuevos @Input/@Output) → el spec del componente necesita casos nuevos.
+- **Acciones o reducers NgRx** → los specs del reducer y los selectors deben revisarse.
+- **Rutas del BFF** → si existen tests de integración, ejecutarlos.
+
+---
+
+### 4. Claves de traducción
+
+Si el template editado introduce texto nuevo o modifica etiquetas existentes:
+
+Recuerda añadir las claves de traducción en:
+```
+src/assets/i18n/es.json    ← Español (principal)
+src/assets/i18n/en.json    ← Inglés (si aplica)
+```
+
+Formato de clave recomendado: `feature.componente.elemento`
+
+```json
+{
+  "partner": {
+    "ofertas": {
+      "titulo": "Mis ofertas",
+      "sin-resultados": "No hay ofertas disponibles"
+    }
+  }
+}
+```
+
+---
+
+### 5. Compatibilidad SSR — revisión final
+
+Si el archivo editado introduce código que accede a APIs del navegador, confirma:
+
+```typescript
+// ✅ Correcto
+import { isPlatformBrowser } from '@angular/common';
+import { PLATFORM_ID, inject } from '@angular/core';
+
+private readonly platformId = inject(PLATFORM_ID);
+
+if (isPlatformBrowser(this.platformId)) {
+  // Código browser-only aquí
+}
+
+// ✅ Alternativa para storage
+private readonly storage = inject(StorageMockService);
+```
+
+Si encontraste acceso inseguro a APIs browser, **indícalo** aunque hayas completado la edición.
+
+---
+
+### 6. Registro de cambios relevantes
+
+Si el cambio es arquitectónico (nuevo store, nuevo interceptor, nueva ruta lazy, nueva dependencia npm), menciona brevemente:
+- Qué se añadió y por qué
+- Qué partes del sistema afecta
+- Si requiere cambios en `app.config.ts`, `app.routes.ts` u otros archivos de configuración
+
+---
+
+## Resumen del flujo post-edit
+
+```
+1. Confirmar que el archivo editado cumple las convenciones del tipo
+
+2. Verificar imports/exports
+   → ¿Necesita barrel update?
+   → ¿Necesita registro en app.config.ts?
+
+3. ¿Se agregó texto visible?
+   → Recordar añadir claves en i18n/
+
+4. ¿Se usaron APIs browser-only?
+   → Verificar protección SSR
+
+5. Indicar comando de test a ejecutar
+
+6. Informar al usuario del resultado y próximos pasos
+```

--- a/.claude/hooks/pre-edit.md
+++ b/.claude/hooks/pre-edit.md
@@ -1,0 +1,111 @@
+# Hook: Pre-Edit — Verificaciones antes de editar un archivo
+
+Este hook define las comprobaciones que Claude debe realizar **antes de modificar cualquier archivo** en este proyecto.
+
+---
+
+## Verificaciones obligatorias
+
+### 1. Archivo protegido — detención inmediata
+
+Si el archivo objetivo pertenece a alguna de estas rutas, **detén la edición y notifica al usuario**:
+
+```
+ssl/
+dist/
+Dockerfile
+docker-entrypoint.sh
+server/config/app.config.js
+```
+
+Mensaje de parada:
+> "⛔ No puedo modificar `<archivo>` — está en la lista de archivos protegidos del proyecto. Si necesitas cambios en esta área, realízalos manualmente."
+
+---
+
+### 2. Leer el archivo antes de editar
+
+**Siempre** usa la herramienta `Read` para leer el contenido completo del archivo antes de proponer cualquier cambio. Nunca edites a ciegas.
+
+---
+
+### 3. Verificar convenciones según tipo de archivo
+
+#### Si es un componente Angular (`*.component.ts`)
+
+Comprueba que el archivo **ya tenga** o que los cambios **mantengan**:
+- `standalone: true` en el decorador `@Component`
+- Ausencia de referencias a NgModule
+- Uso de `inject()` para dependencias (no `constructor` con DI, salvo herencia)
+
+Si detectas una violación existente, **no la propagues** en tu edición y menciona el hallazgo.
+
+#### Si es un template Angular (`*.component.html`)
+
+Verifica que el template objetivo usa (o seguirá usando tras el cambio):
+- `@if` / `@for` / `@let` — **no** `*ngIf` / `*ngFor` / `*ngSwitch`
+- `{{ 'clave' | translate }}` para cualquier texto visible — **no** strings en duro
+- Sin URLs hardcodeadas en `href`, `src` o `[routerLink]` absolutas externas
+
+#### Si es un effect NgRx (`*.effects.ts`)
+
+Verifica:
+- Existe un `catchError` que despacha la acción `*Fallido`
+- No hay llamadas HTTP directas al backend Java (sin pasar por el BFF)
+
+#### Si es un archivo del BFF (`server/**/*.js`)
+
+Verifica:
+- No se introducen credenciales o secrets en duro
+- Las URLs de backend se leen de `process.env.*` o de la config central
+- No se expone información sensible en las respuestas
+
+#### Si es un archivo de entorno (`src/environments/*.ts`)
+
+- Confirmar que solo contiene `environment.*` — sin credenciales reales
+- Verificar que no se añaden URLs de backend Java directas (van en el BFF)
+
+---
+
+### 4. Comprobación SSR
+
+Si el archivo modificado usa cualquiera de estas APIs:
+- `window`, `document`, `navigator`, `location`
+- `localStorage`, `sessionStorage`, `indexedDB`
+- `setTimeout`, `setInterval` (sin cleanup)
+
+Verifica que estén envueltas con `isPlatformBrowser()` o que usen `StorageMockService`. Si no lo están, avisa antes de proceder.
+
+---
+
+### 5. Impacto en tests
+
+Si el archivo modificado tiene un `*.spec.ts` correspondiente:
+- Menciona que los tests pueden necesitar actualización.
+- Si el cambio afecta la interfaz pública (inputs, outputs, métodos públicos, acciones NgRx), indica qué specs deben revisarse.
+
+---
+
+## Resumen del flujo pre-edit
+
+```
+1. ¿Es un archivo protegido?
+   → SÍ: Detener y notificar
+   → NO: Continuar
+
+2. Leer el archivo completo
+
+3. ¿Es un componente Angular?
+   → Verificar standalone, inject(), sin NgModule
+
+4. ¿Es un template?
+   → Verificar @if/@for/@let, | translate, sin strings en duro
+
+5. ¿Usa APIs browser-only?
+   → Verificar protección SSR
+
+6. ¿Tiene spec correspondiente?
+   → Avisar sobre posible actualización de tests
+
+7. Proceder con la edición
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit(src/)",
+      "Write(src/)",
+      "Edit(server/)",
+      "Write(server/)",
+      "Edit(.claude/)",
+      "Write(.claude/)",
+      "Bash(ng:*)",
+      "Bash(npm run:*)",
+      "Bash(npm test:*)",
+      "Bash(npm install:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git branch:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(jq:*)"
+    ],
+    "deny": [
+      "Edit(ssl/)",
+      "Write(ssl/)",
+      "Edit(dist/)",
+      "Write(dist/)",
+      "Edit(Dockerfile)",
+      "Write(Dockerfile)",
+      "Edit(docker-entrypoint.sh)",
+      "Write(docker-entrypoint.sh)",
+      "Edit(server/config/app.config.js)",
+      "Write(server/config/app.config.js)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -Rs '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":.}}' .claude/hooks/pre-edit.md 2>/dev/null || true",
+            "timeout": 10,
+            "statusMessage": "Verificando convenciones pre-edición..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command'); echo \"$cmd\" | grep -qE '(^|[ /])(ssl|dist)/|(\\bDockerfile\\b|\\bdocker-entrypoint\\.sh\\b)' && echo '{\"continue\":false,\"stopReason\":\"Bloqueado: el comando afecta archivos protegidos del proyecto (ssl/, dist/, Dockerfile, docker-entrypoint.sh).\"}' || true",
+            "timeout": 5,
+            "statusMessage": "Verificando comando Bash..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -Rs '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":.}}' .claude/hooks/post-edit.md 2>/dev/null || true",
+            "timeout": 10,
+            "statusMessage": "Aplicando verificaciones post-edición..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,202 @@
+# CLAUDE.md — Directory Frontend
+
+Guía de trabajo para Claude Code en este repositorio. Lee este archivo antes de tocar cualquier código.
+
+---
+
+## Stack tecnológico
+
+| Categoría | Tecnología |
+|-----------|-----------|
+| Framework | Angular 20.3.3 con SSR (`@angular/ssr`) |
+| Estado global | NgRx 20 (Store, Effects, Devtools) |
+| Estado local | Signals de Angular (solo en componentes) |
+| Estilos | Tailwind CSS v4 + Angular Material (tema Azure Blue) |
+| Traducciones | `@ngx-translate/core` v16 — idioma por defecto: `es` |
+| BFF | Express.js en `server/` — intermediario obligatorio hacia el backend Java |
+| Sesión | Redis + fallback en memoria (`server/shared/redis-session-store.js`) |
+| Autenticación | JWT + OAuth/Keycloak |
+| Testing | Karma + Jasmine + ChromeHeadlessNoSandbox |
+| TypeScript | 5.7.3 en modo `strict` |
+
+---
+
+## Aliases de rutas (tsconfig.json)
+
+```
+@app/*    → src/app/*
+@core/*   → src/app/core/*
+@shared/* → src/app/shared/*
+@env/*    → src/environments/*
+assets/*  → src/assets/*
+```
+
+Usa siempre estos aliases; nunca rutas relativas que suban más de dos niveles.
+
+---
+
+## Reglas absolutas (no negociables)
+
+### Componentes
+
+- **Siempre `standalone: true`** — no uses NgModule bajo ninguna circunstancia.
+- La inyección de dependencias se hace con la función `inject()`, no con el constructor (salvo herencia que lo requiera).
+- Usa **`@if` / `@for` / `@let`** del nuevo control flow — nunca `*ngIf` / `*ngFor` / `*ngSwitch`.
+- Todos los textos visibles al usuario deben pasar por el pipe **`| translate`** de ngx-translate. Cero strings en duro en templates.
+- Importa explícitamente en el array `imports: []` del decorador todo lo que el template necesite.
+
+### Estado
+
+- **NgRx** para estado global (store, actions, reducers, effects, selectors).
+- **Signals** de Angular únicamente para estado local interno del componente.
+- Estructura de feature store: `state.ts`, `actions.ts`, `reducer.ts`, `effects.ts`, `selectors.ts`, `store.service.ts`.
+- Convención de nombre de acción: `[Feature] Verbo sustantivo` (ej. `[Session] Save session`).
+
+### HTTP / BFF
+
+- **Nunca llames directamente al backend Java** desde el código Angular. Toda llamada HTTP pasa por el BFF en `server/`.
+- En Angular usa `HttpService` (`@core/services/http.service.ts`) — nunca `HttpClient` directamente.
+- Las URLs se construyen a partir de constantes en `DFC` (directorio de constantes) o de `environment.ts`. Cero URLs hardcodeadas.
+
+### SSR
+
+- Cualquier uso de `window`, `document`, `localStorage` o `sessionStorage` debe ir protegido con `isPlatformBrowser()` o usar `StorageMockService`.
+- Marca con un comentario `// SSR: browser-only` cualquier código que detectes que no es compatible con SSR e indícalo al desarrollador.
+
+### Archivos intocables
+
+Nunca modifiques ni elimines:
+
+```
+ssl/
+dist/
+Dockerfile
+docker-entrypoint.sh
+server/config/app.config.js   ← Vault / secrets
+```
+
+---
+
+## Convenciones de código
+
+### Componentes — plantilla mínima
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-mi-componente',
+  standalone: true,
+  imports: [TranslateModule],
+  templateUrl: './mi-componente.component.html',
+  styleUrls: ['./mi-componente.component.css']
+})
+export class MiComponenteComponent {
+  private readonly miServicio = inject(MiServicio);
+}
+```
+
+### Template — control flow moderno
+
+```html
+@if (condicion) {
+  <p>{{ 'clave.traduccion' | translate }}</p>
+}
+
+@for (item of items(); track item.id) {
+  <app-item [data]="item" />
+}
+
+@let valor = signal$ | async;
+```
+
+### Servicios
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class MiServicio {
+  private readonly http = inject(HttpService);
+  // ...
+}
+```
+
+### NgRx — acciones
+
+```typescript
+export const cargarDatos = createAction('[Feature] Cargar datos');
+export const cargarDatosExitoso = createAction(
+  '[Feature] Cargar datos exitoso',
+  props<{ datos: MiModelo[] }>()
+);
+export const cargarDatosFallido = createAction(
+  '[Feature] Cargar datos fallido',
+  props<{ error: string }>()
+);
+```
+
+---
+
+## Estructura de directorios relevante
+
+```
+src/app/
+├── core/
+│   ├── guards/          # Guardias de ruta
+│   ├── interceptors/    # Interceptores HTTP
+│   ├── services/        # Servicios core (auth, http, logger, notification…)
+│   └── store/           # NgRx stores (session, …)
+├── features/            # Módulos de feature con lazy loading
+│   ├── auth/
+│   ├── partner/
+│   └── community-member/
+├── components/
+│   └── ui/              # Componentes UI reutilizables (Button, Badge, Card…)
+├── layout/              # Footer, NotFound, ReportProblem
+├── shared/              # Modelos, pipes, constantes compartidas
+└── header/
+
+server/                  # BFF Express.js
+├── config/
+├── controller/
+├── routes/
+├── proxy/
+└── shared/
+
+src/environments/        # Variables de entorno por ambiente
+```
+
+---
+
+## Testing
+
+```bash
+# Comando estándar (siempre usar este)
+ng test --code-coverage --no-watch --browsers ChromeHeadlessNoSandbox
+
+# Con navegador interactivo (solo desarrollo local)
+npm run test:browser
+```
+
+- Crea archivos `*.spec.ts` en la misma carpeta que el archivo que testeas.
+- Mockea dependencias externas; no hagas llamadas HTTP reales en tests unitarios.
+- El coverage mínimo aceptable es el que ya está configurado en `karma.conf.js`.
+
+---
+
+## Comandos útiles disponibles
+
+| Comando | Descripción |
+|---------|-------------|
+| `/gen-component` | Genera un componente Angular standalone completo |
+| `/gen-ngrx-feature` | Genera un feature completo de NgRx |
+| `/gen-service` | Genera un servicio Angular |
+| `/review-pr` | Revisa un PR siguiendo las convenciones del proyecto |
+
+---
+
+## Reglas de idioma
+
+- Todo el contenido visible al usuario (templates, traducciones, notificaciones) debe estar en **español** o gestionado via ngx-translate.
+- Los archivos de traducción están en `src/assets/i18n/`.
+- Añade siempre las claves de traducción necesarias al crear o modificar UI.


### PR DESCRIPTION
Set up Claude Code configuration for the project (DS-177)

Adds the `.claude/` folder and `CLAUDE.md` to establish Claude Code's 
behavior in this repository. All configuration was inferred directly 
from the existing codebase.

**What's included:**
- `CLAUDE.md` — project context: stack, conventions, protected files and 
  out-of-scope rules
- `.claude/commands/` — reusable slash commands: gen-component, 
  gen-ngrx-feature, gen-service, review-pr
- `.claude/agents/` — specialized agents: angular-ui (UI layer), 
  ngrx (state management), bff (Node/Express server layer)
- `.claude/hooks/` — pre-edit and post-edit safety checks

**Key behaviors enforced:**
- Standalone components only, never NgModule
- NgRx for global state, signals for local state
- All HTTP through the BFF (server/) — never direct to Spring Boot
- SSR-safe code checks on every edit
- Protected files: ssl/, dist/, Dockerfile, docker-entrypoint.sh, 
  server/config/app.config.js (Vault)
- All responses in Spanish

No existing files were modified.