### PR TITLE
Update project settings and add commands

### DIFF
--- a/.claude/commands/add-i18n.md
+++ b/.claude/commands/add-i18n.md
@@ -1,0 +1,145 @@
+# /add-i18n — Add Missing Translation Keys
+
+Finds all strings pending internationalization in the project and adds the corresponding keys to the i18n JSON files.
+
+## Usage
+
+```
+/add-i18n [--feature <feature>] [--file <path>]
+```
+
+**Examples:**
+- `/add-i18n` — scans the entire project
+- `/add-i18n --feature partner` — scans only `src/app/features/partner/`
+- `/add-i18n --file src/app/features/partner/components/offer-card/offer-card.component.html`
+
+---
+
+## Steps
+
+### 1. Find pending strings
+
+Search for all occurrences of the following patterns:
+
+**In TypeScript files (`*.component.ts`, `*.service.ts`):**
+```
+// TODO: i18n
+```
+
+**In HTML templates (`*.component.html`):**
+```
+<!-- TODO: i18n -->
+```
+
+Use grep to find them:
+```bash
+grep -rn "TODO: i18n" src/app/ --include="*.ts" --include="*.html"
+```
+
+### 2. For each match, read the surrounding context
+
+Read the file and identify:
+- The exact visible string the user sees (e.g., `'Guardar cambios'`, `'Error al cargar'`)
+- The component/feature it belongs to
+- The semantic meaning of the string
+
+### 3. Propose the translation key
+
+Use the format `feature.component.element`:
+
+```
+partner.offer-card.title       → "Mis ofertas"
+partner.offer-card.no-results  → "No hay ofertas disponibles"
+auth.login.submit              → "Iniciar sesión"
+community-member.profile.edit  → "Editar perfil"
+```
+
+Rules for key names:
+- kebab-case at every level
+- Maximum 3 levels: `feature.component.element`
+- Descriptive and semantic — not positional (`button-1` is wrong, `submit` is right)
+- Never duplicate an existing key — check `es.json` first before proposing
+
+### 4. Read the existing i18n files
+
+Always read both files before writing:
+```
+src/assets/i18n/es.json
+src/assets/i18n/en.json
+```
+
+Verify that the proposed key does not already exist (same key, possibly different value).
+
+### 5. Add the keys
+
+Insert the new keys into the correct nested position in both files, preserving the JSON structure and alphabetical order within each object.
+
+**Before:**
+```json
+{
+  "partner": {
+    "dashboard": {
+      "title": "Panel de control"
+    }
+  }
+}
+```
+
+**After adding `partner.offer-card.title`:**
+```json
+{
+  "partner": {
+    "dashboard": {
+      "title": "Panel de control"
+    },
+    "offer-card": {
+      "title": "Mis ofertas"
+    }
+  }
+}
+```
+
+For `en.json`, provide the English translation. If uncertain, use the Spanish string prefixed with `[EN]` as a placeholder and note it for manual review.
+
+### 6. Replace the hardcoded strings in the source files
+
+After adding the keys, replace each hardcoded string with its translation pipe:
+
+**In templates:**
+```html
+<!-- Before -->
+<h2>Guardar cambios</h2> <!-- TODO: i18n -->
+
+<!-- After -->
+<h2>{{ 'partner.offer-card.title' | translate }}</h2>
+```
+
+**In TypeScript (using TranslateService):**
+```typescript
+// Before
+const message = 'Error al cargar'; // TODO: i18n
+
+// After — inject TranslateService
+private readonly translate = inject(TranslateService);
+const message = this.translate.instant('partner.offer-card.error');
+```
+
+### 7. Report
+
+After finishing, report:
+- Total `// TODO: i18n` found
+- Keys added to `es.json` and `en.json`
+- Files modified
+- Any translations left as `[EN]` placeholder that need manual review
+
+---
+
+## Checklist
+
+- [ ] Grep run to find all pending strings in the target scope
+- [ ] No existing key overwritten in `es.json` / `en.json`
+- [ ] New keys follow `feature.component.element` format in kebab-case
+- [ ] Both `es.json` and `en.json` updated
+- [ ] `<!-- TODO: i18n -->` / `// TODO: i18n` comments removed after replacement
+- [ ] `| translate` pipe added in the template (or `TranslateService.instant()` in TypeScript)
+- [ ] Valid JSON maintained — no trailing commas

--- a/.claude/commands/commit-msg.md
+++ b/.claude/commands/commit-msg.md
@@ -1,0 +1,47 @@
+---
+name: commit-msg
+description: Generate a short, concise commit message based on staged or unstaged changes. Use when asked to "write a commit message", "suggest a commit", "what should I commit?", or "commit message for these changes".
+model: claude-haiku-4-5-20251001
+---
+
+Run `git diff --staged` (and `git diff` if nothing is staged) to see what changed. Then generate a commit message following these rules:
+
+## Rules
+
+- **One line only** — no body, no bullet points, no explanation
+- **50 chars or fewer** — hard limit
+- **Imperative mood** — "Add", "Fix", "Remove", "Update", "Refactor" (not "Added" or "Adds")
+- **No period at the end**
+- **No ticket numbers, no co-authors, no metadata** unless the user asks
+- **In the same language as the repo's existing commit history** — check with `git log --oneline -5`
+
+## Output format
+
+Print only the full git command, ready to copy-paste. No explanation, no labels, nothing else:
+
+```
+git commit -m "Verb what changed"
+```
+
+## How to pick the verb
+
+| Change type | Verb |
+|---|---|
+| New file / feature | `Add` |
+| Bug fix | `Fix` |
+| Delete code/file | `Remove` |
+| Update existing behavior | `Update` |
+| Rename / move | `Rename` / `Move` |
+| Refactor (no behavior change) | `Refactor` |
+| Config / env / infra | `Configure` |
+| Docs / README | `Document` |
+| Dependencies | `Bump` |
+
+## Steps
+
+1. `git log --oneline -5` — check the language and style of existing commits
+2. `git diff --staged` — see staged changes; if empty, run `git diff` instead
+3. Identify the single most important change (not a list of everything)
+4. Output one line: `git commit -m "<Verb> <what changed>"`
+
+If the diff is empty (nothing staged, nothing modified), say: "No changes detected — nothing to commit."

--- a/.claude/commands/gen-spec.md
+++ b/.claude/commands/gen-spec.md
@@ -1,0 +1,232 @@
+# /gen-spec — Generate Unit Test File
+
+Generates a `.spec.ts` file for an existing Angular component, service, NgRx reducer, selector, or effect that lacks tests.
+
+## Usage
+
+```
+/gen-spec <path>
+```
+
+**Examples:**
+- `/gen-spec src/app/features/partner/components/offer-card/offer-card.component.ts`
+- `/gen-spec src/app/core/services/business/business.client.ts`
+- `/gen-spec src/app/features/partner/store/partner.reducer.ts`
+- `/gen-spec src/app/features/partner/store/partner.effects.ts`
+
+---
+
+## Steps before generating
+
+1. **Read the source file** completely before writing any test.
+2. Identify the file type from the path:
+   - `*.component.ts` → Component spec
+   - `*.service.ts` / `*.client.ts` → Service spec
+   - `*.reducer.ts` → Reducer spec
+   - `*.selectors.ts` → Selector spec
+   - `*.effects.ts` → Effects spec
+3. Check whether a `*.spec.ts` already exists at the same path. If it does, report it and ask for confirmation before overwriting.
+4. Identify all public methods, `input()` / `@Input()`, `output()` / `@Output()`, injected dependencies, and relevant NgRx actions.
+
+---
+
+## Component spec
+
+```typescript
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { <NameComponent> } from './<name>.component';
+
+describe('<NameComponent>', () => {
+  let component: <NameComponent>;
+  let fixture: ComponentFixture<<NameComponent>>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        <NameComponent>,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        // Mock each injected service
+        { provide: MyService, useValue: jasmine.createSpyObj('MyService', ['method']) }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(<NameComponent>);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // One test per input() / @Input() — verify template binding
+  // One test per output() / @Output() — trigger the event and assert the emission
+  // One test per conditional @if block — verify the DOM changes
+});
+```
+
+Rules:
+- Never make real HTTP calls — mock all services with `jasmine.createSpyObj`.
+- If the component uses the NgRx store, mock via `provideMockStore()` from `@ngrx/store/testing`.
+- If the component uses `TranslateModule`, always include `TranslateModule.forRoot()`.
+- If the component uses `RouterModule` or `RouterLink`, include `RouterTestingModule`.
+
+---
+
+## Service / Client spec
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { <NameService> } from './<name>.service';
+
+describe('<NameService>', () => {
+  let service: <NameService>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [<NameService>]
+    });
+    service = TestBed.inject(<NameService>);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  // One test per public method — verify URL, method, and return type
+});
+```
+
+For `bff-client` services, use `HttpService` spy instead of `HttpTestingController`:
+
+```typescript
+providers: [
+  { provide: HttpService, useValue: jasmine.createSpyObj('HttpService', ['get', 'post', 'put', 'delete']) }
+]
+```
+
+---
+
+## Reducer spec
+
+```typescript
+import { reducer, initialState } from './<feature>.reducer';
+import * as <Feature>Actions from './<feature>.actions';
+
+describe('<Feature>Reducer', () => {
+  it('should return initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual(initialState);
+  });
+
+  it('should set loading on <load> action', () => {
+    const state = reducer(initialState, <Feature>Actions.load());
+    expect(state.loading).toBeTrue();
+  });
+
+  it('should populate data on <loadSuccess>', () => {
+    const items = [/* mock data */];
+    const state = reducer({ ...initialState, loading: true }, <Feature>Actions.loadSuccess({ items }));
+    expect(state.items).toEqual(items);
+    expect(state.loading).toBeFalse();
+  });
+
+  it('should capture error on <loadFailure>', () => {
+    const state = reducer({ ...initialState, loading: true }, <Feature>Actions.loadFailure({ error: 'Error' }));
+    expect(state.error).toBe('Error');
+    expect(state.loading).toBeFalse();
+  });
+});
+```
+
+---
+
+## Selectors spec
+
+```typescript
+import * as <Feature>Selectors from './<feature>.selectors';
+import { initialState } from './<feature>.reducer';
+
+describe('<Feature> selectors', () => {
+  const state = { <feature>: { ...initialState, items: [/* mock */] } };
+
+  it('should select items', () => {
+    expect(<Feature>Selectors.selectItems.projector(state.<feature>)).toEqual(state.<feature>.items);
+  });
+
+  it('should report not loading', () => {
+    expect(<Feature>Selectors.selectLoading.projector(state.<feature>)).toBeFalse();
+  });
+});
+```
+
+---
+
+## Effects spec
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Observable, of, throwError } from 'rxjs';
+import { Action } from '@ngrx/store';
+import { <Feature>Effects } from './<feature>.effects';
+import * as <Feature>Actions from './<feature>.actions';
+
+describe('<Feature>Effects', () => {
+  let actions$: Observable<Action>;
+  let effects: <Feature>Effects;
+  let featureService: jasmine.SpyObj<<FeatureService>>;
+
+  beforeEach(() => {
+    featureService = jasmine.createSpyObj('<FeatureService>', ['getAll']);
+    TestBed.configureTestingModule({
+      providers: [
+        <Feature>Effects,
+        provideMockActions(() => actions$),
+        { provide: <FeatureService>, useValue: featureService }
+      ]
+    });
+    effects = TestBed.inject(<Feature>Effects);
+  });
+
+  it('should dispatch loadSuccess on successful fetch', (done) => {
+    const items = [/* mock */];
+    featureService.getAll.and.returnValue(of(items));
+    actions$ = of(<Feature>Actions.load());
+
+    effects.load$.subscribe(action => {
+      expect(action).toEqual(<Feature>Actions.loadSuccess({ items }));
+      done();
+    });
+  });
+
+  it('should dispatch loadFailure on error', (done) => {
+    featureService.getAll.and.returnValue(throwError(() => new Error('Error')));
+    actions$ = of(<Feature>Actions.load());
+
+    effects.load$.subscribe(action => {
+      expect(action).toEqual(<Feature>Actions.loadFailure({ error: 'Error' }));
+      done();
+    });
+  });
+});
+```
+
+---
+
+## Checklist before delivering
+
+- [ ] No real HTTP calls — all external dependencies mocked
+- [ ] `afterEach(() => httpMock.verify())` present when using `HttpTestingController`
+- [ ] At least one test per public method / input / output
+- [ ] `TranslateModule.forRoot()` included for components with `| translate`
+- [ ] NgRx store mocked with `provideMockStore()` when used
+- [ ] File placed in the same directory as the source file

--- a/.claude/commands/pr-description.md
+++ b/.claude/commands/pr-description.md
@@ -1,0 +1,34 @@
+---
+name: pr-description
+description: Generate a clear PR description with summary, changes, motivation, and test plan. Use when asked to "write a PR description", "describe this PR", "generate PR body", or before creating a pull request.
+model: claude-haiku-4-5-20251001
+---
+
+## Steps
+
+Run these commands **in parallel**:
+- `git log development..HEAD --oneline`
+- `git diff --stat development...HEAD`
+
+If no commits appear, say: "No commits detected on this branch relative to development." and stop.
+
+If there are commits, read only the files that changed (use `git show <file>` or Read) — **do not run `git diff` without `--stat`**.
+
+## Output
+
+Write a PR description with exactly these three sections:
+
+```
+## Summary
+[2 sentences max: what changed and why — fold motivation into this]
+
+## Changes
+- [3–5 bullets grouping related changes, not listing every file]
+
+## Test Plan
+- [3 bullets: what to verify, how, and one edge case]
+```
+
+Rules: conversational tone, no fluff, no ticket numbers, imperative verbs in bullets.
+
+Save the result to `.pr-description.md` using the Write tool.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,11 +12,10 @@
       "Edit(docs/)",
       "Write(docs/)",
       "Bash(ng:*)",
-      "Bash(npm run:*)",
-      "Bash(npm test:*)",
-      "Bash(npm install:*)",
-      "Bash(npm ci:*)",
-      "Bash(npm audit:*)",
+      "Bash(pnpm run:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm audit:*)",
       "Bash(git status:*)",
       "Bash(git log:*)",
       "Bash(git diff:*)",
@@ -27,6 +26,11 @@
       "Bash(git pull:*)",
       "Bash(gh pr:*)",
       "Bash(gh issue:*)",
+      "Bash(grep:*)",
+      "Bash(find .:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(npx:*)",
       "Bash(jq:*)",
       "Bash(node --check:*)",
       "Bash(node -e:*)"
@@ -47,17 +51,6 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -Rs '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":.}}' .claude/hooks/pre-edit.md 2>/dev/null || true",
-            "timeout": 10,
-            "statusMessage": "Verificando convenciones pre-edición..."
-          }
-        ]
-      },
-      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -65,19 +58,6 @@
             "command": "cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null); [ -z \"$cmd\" ] && exit 0; echo \"$cmd\" | grep -qE '(^|[ /])(ssl|dist)/|(\\bDockerfile\\b|\\bdocker-entrypoint\\.sh\\b)' && echo '{\"continue\":false,\"stopReason\":\"Bloqueado: el comando afecta archivos protegidos del proyecto (ssl/, dist/, Dockerfile, docker-entrypoint.sh).\"}' || true",
             "timeout": 5,
             "statusMessage": "Verificando comando Bash..."
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -Rs '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":.}}' .claude/hooks/post-edit.md 2>/dev/null || true",
-            "timeout": 10,
-            "statusMessage": "Aplicando verificaciones post-edición..."
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ package-lock.json
 /vscode/*
 /default.env
 /pnpm-lock.yaml
+.pr-description.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ src/environments/        # Variables de entorno por ambiente
 ng test --code-coverage --no-watch --browsers ChromeHeadlessNoSandbox
 
 # Con navegador interactivo (solo desarrollo local)
-npm run test:browser
+pnpm run test:browser
 ```
 
 - Crea archivos `*.spec.ts` en la misma carpeta que el archivo que testeas.
@@ -210,10 +210,10 @@ npm run test:browser
 
 ### Reglas
 
-- Ejecuta `npm audit` antes de todo PR que toque dependencias
+- Ejecuta `pnpm audit` antes de todo PR que toque dependencias
 - Tolerancia cero para vulnerabilidades `critical` o `high` en merge
-- Usa `npm ci` en CI/CD, nunca `npm install`
-- Nunca ejecutes `npm audit fix --force` sin rama separada y suite de tests pasando
+- Usa `pnpm install --frozen-lockfile` en CI/CD, nunca `pnpm install` sin flag
+- Nunca ejecutes `pnpm audit --fix` sin rama separada y suite de tests pasando
 - Al actualizar Angular, actualiza **todos** los paquetes `@angular/*` a la vez — comparten peer deps y deben estar en la misma versión de patch
 
 ### Al añadir dependencias
@@ -231,5 +231,5 @@ npm run test:browser
 
 ```yaml
 - name: Security audit
-  run: npm audit --audit-level=high
+  run: pnpm audit --audit-level high
 ```


### PR DESCRIPTION
## Summary

This PR updates the project's Claude Code configuration and documentation to align with pnpm as the package manager, and adds three new command guides for enhanced developer workflow. Simplifies the settings by removing complex hook validations while expanding tool permissions for better command execution.

## Changes

- **Added command documentation files** (`.claude/commands/`):
  - `add-i18n.md` — guide for finding and adding missing translation keys
  - `commit-msg.md` — guide for generating concise commit messages
  - `gen-spec.md` — guide for auto-generating unit test files for components and services

- **Updated `.claude/settings.json`**:
  - Replaced all `npm` commands with `pnpm` equivalents (run, test, install, audit)
  - Removed complex pre/post-edit hooks for validation
  - Added new allowed bash commands: `grep`, `find`, `ls`, `cat`, `npx`

- **Updated `CLAUDE.md`**:
  - Changed all `npm` references to `pnpm` (test command, audit rules, CI/CD instructions)

## Motivation & Context

The project uses pnpm as its package manager, but the Claude Code configuration still referenced npm. This created friction when Claude suggested or executed npm commands. The new command documentation files provide clear runbooks for common developer tasks like managing translations, writing commit messages, and generating tests — reducing manual work and improving consistency.

Removing the pre/post-edit hooks simplifies the configuration without losing value, since most validations are covered by TypeScript strict mode, linters, and the test suite. Adding grep, find, ls, and cat to the allowlist reduces permission prompts for routine file exploration.

## Test Plan

- Verify that Claude Code now suggests and runs `pnpm` commands in contexts where it previously would have suggested `npm`
- Test the `/add-i18n`, `/commit-msg`, and `/gen-spec` commands are available and execute correctly
- Confirm that bash commands like `grep` and `find` no longer trigger permission prompts when used for code exploration
- Check that existing builds and tests still pass with the configuration changes